### PR TITLE
Added line variable for easier animation with css

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ line individually. Works with nested HTML tags.
 ### Result
 
     <div id="mytext">
-        <div><span class="someClass">This is an</span></div>
-        <div><span class="someClass"><strong>example</strong> of</span></div>
-        <div><span class="someClass">some long</span></div>
-        <div><span class="someClass">text that we</span></div>
-        <div><span class="someClass">want to split</span></div>
-        <div><span class="someClass">into lines.</span></div>
+        <div style="--line-index:0;"><span class="someClass">This is an</span></div>
+        <div style="--line-index:1;"><span class="someClass"><strong>example</strong> of</span></div>
+        <div style="--line-index:2;"><span class="someClass">some long</span></div>
+        <div style="--line-index:3;"><span class="someClass">text that we</span></div>
+        <div style="--line-index:4;"><span class="someClass">want to split</span></div>
+        <div style="--line-index:5;"><span class="someClass">into lines.</span></div>
     </div>
 
 Now go forth, and animate!

--- a/demos.html
+++ b/demos.html
@@ -3,7 +3,7 @@
 	<head>
 		<title></title>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.4/jquery.min.js"></script>
 		<script src="jquery.splitlines.js"></script>
 		<style type="text/css">
 			body {

--- a/demos.html
+++ b/demos.html
@@ -10,6 +10,7 @@
 				font-family: 'Lucida Sans', Helvetica, Arial, sans-serif;
 				margin-left:20px;
 				margin-top:20px;
+				margin-bottom: 100px;
 			}
 			h1 {
 				font-size: 30px;
@@ -56,6 +57,9 @@
 				font-size: 14px;
 			}
 			#original-11, #example-11 {
+				max-width: 300px;
+			}
+			#original-12, #example-12 {
 				max-width: 300px;
 			}
 
@@ -117,6 +121,9 @@
 				$('#example-9').splitLines({width: 150});
 				$('#example-10 p').splitLines({tag:'<span style="display:inline-block;">'});
 				$('#example-11').splitLines({
+					tag: '<div class="animated-line-content">'
+				});
+				$('#example-12').splitLines({
 					tag: '<div class="animated-line-wrapper"><div class="animated-line-content">'
 				});
 
@@ -243,6 +250,16 @@
 						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est libero, eget convallis mauris viverra eu.
 					</div>
 					<div id="example-11" class="example">
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est libero, eget convallis mauris viverra eu.
+					</div>
+				</div>
+
+				<div>
+					<p>A test using <code>--line-index</code> CSS variable and extra tag wrappers to animate lines.</p>
+					<div id="original-12" class="original">
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est libero, eget convallis mauris viverra eu.
+					</div>
+					<div id="example-12" class="example">
 						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est libero, eget convallis mauris viverra eu.
 					</div>
 				</div>

--- a/demos.html
+++ b/demos.html
@@ -3,7 +3,7 @@
 	<head>
 		<title></title>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-		<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.4/jquery.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
 		<script src="jquery.splitlines.js"></script>
 		<style type="text/css">
 			body {
@@ -55,10 +55,29 @@
 				font-family: sans-serif;
 				font-size: 14px;
 			}
+			#original-11, #example-11 {
+				max-width: 300px;
+			}
 
 			.code {
 				font-family: monospace;
 				display:inline;
+			}
+
+			.animated-line-content {
+				opacity: 0;
+				animation: animtext-up .75s cubic-bezier(0.77, 0, 0.175, 1) forwards;
+				animation-delay: calc(.15s * var(--line-index));
+			}
+			@keyframes animtext-up {
+				from {
+					transform: translateY(100%);
+					opacity: 0;
+				}
+				to {
+					transform: translateY(0);
+					opacity: 1;
+				}
 			}
 		</style>
 		<script type="text/javascript">
@@ -97,6 +116,9 @@
 				$('#example-8').splitLines({width: 10});
 				$('#example-9').splitLines({width: 150});
 				$('#example-10 p').splitLines({tag:'<span style="display:inline-block;">'});
+				$('#example-11').splitLines({
+					tag: '<div class="animated-line-wrapper"><div class="animated-line-content">'
+				});
 
 				$('#example-6').css('height', 24).children().css({
 					position: 'absolute',
@@ -212,6 +234,16 @@
 					</div>
 					<div id="example-10" class="example">
 						<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est libero, eget convallis mauris viverra eu. Fusce erat urna, blandit sed ex sit amet, sollicitudin pellentesque ex.</p>
+					</div>
+				</div>
+
+				<div>
+					<p>A test using <code>--line-index</code> CSS variable to animate lines.</p>
+					<div id="original-11" class="original">
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est libero, eget convallis mauris viverra eu.
+					</div>
+					<div id="example-11" class="example">
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est libero, eget convallis mauris viverra eu.
 					</div>
 				</div>
 			</div>

--- a/jquery.splitlines.js
+++ b/jquery.splitlines.js
@@ -73,18 +73,23 @@
  *
  * @param tag
  * @param html content wrapped by the tag
+ * @param line Current line index
  */
 	function _markupContent(tag, html, line) {
 		// wrap in a temp div so .html() gives us the tags we specify
-		tag = '<div>' + tag;
+		tag = '<div class="stop">' + tag;
 		// find the deepest child, add html, then find the parent
-		return $(tag)
+		var $outer = $(tag)
 			.find('*:not(:has("*"))')
 			.html(html)
-			.parentsUntil()
-			.css('--line-index', line)
-			.slice(-1)
-			.html();
+			.closest('.stop')
+			.slice(-1);
+
+		$outer
+			.children()
+			.css('--line-index', line);
+
+		return $outer.html();
 	}
 
 /**

--- a/jquery.splitlines.js
+++ b/jquery.splitlines.js
@@ -125,20 +125,20 @@
 			if (tempLine.html() == prev) {
 				// repeating word, it will never fit so just use it instead of failing
 				prev = '';
-				newHtml.append(_markupContent(settings.tag, tempLine.html(), lineCount)));
+				newHtml.append(_markupContent(settings.tag, tempLine.html(), lineCount));
 				tempLine.html('');
 				continue;
 			}
 			if (tempLine.height() > maxHeight) {
 				prev = tempLine.html();
 				tempLine.html(html);
-				newHtml.append(_markupContent(settings.tag, tempLine.html(), lineCount)));
+				newHtml.append(_markupContent(settings.tag, tempLine.html(), lineCount));
 				tempLine.html('');
 				w--;
 				lineCount++;
 			}
 		}
-		newHtml.append(_markupContent(settings.tag, tempLine.html(), lineCount)));
+		newHtml.append(_markupContent(settings.tag, tempLine.html(), lineCount));
 
 		this.html(newHtml.html());
 

--- a/jquery.splitlines.js
+++ b/jquery.splitlines.js
@@ -73,9 +73,9 @@
  *
  * @param tag
  * @param html content wrapped by the tag
- * @param line Current line index
+ * @param index Current line index
  */
-	function _markupContent(tag, html, line) {
+	function _markupContent(tag, html, index) {
 		// wrap in a temp div so .html() gives us the tags we specify
 		tag = '<div class="stop">' + tag;
 		// find the deepest child, add html, then find the parent
@@ -87,7 +87,7 @@
 
 		$outer
 			.children()
-			.css('--line-index', line);
+			.css('--line-index', index);
 
 		return $outer.html();
 	}

--- a/jquery.splitlines.js
+++ b/jquery.splitlines.js
@@ -85,9 +85,10 @@
 			.closest('.stop')
 			.slice(-1);
 
-		$outer
-			.children()
-			.css('--line-index', index);
+		// jQuery does not support setting CSS vars until 3.2, so manually set them
+		$outer.children().each(function (i, element) {
+			element.style.setProperty('--line-index', index);
+		});
 
 		return $outer.html();
 	}

--- a/jquery.splitlines.js
+++ b/jquery.splitlines.js
@@ -74,7 +74,7 @@
  * @param tag
  * @param html content wrapped by the tag
  */
-	function _markupContent(tag, html) {
+	function _markupContent(tag, html, line) {
 		// wrap in a temp div so .html() gives us the tags we specify
 		tag = '<div>' + tag;
 		// find the deepest child, add html, then find the parent
@@ -82,6 +82,7 @@
 			.find('*:not(:has("*"))')
 			.html(html)
 			.parentsUntil()
+			.css('--line-index', line)
 			.slice(-1)
 			.html();
 	}
@@ -117,25 +118,27 @@
 		this.append(tempLine);
 		var words = settings.keepHtml ? _splitHtmlWords(contents) : _splitWords(text);
 		var prev;
+		var lineCount = 0;
 		for (var w=0; w<words.length; w++) {
 			var html = tempLine.html();
 			tempLine.html(html+words[w]+' ');
 			if (tempLine.html() == prev) {
 				// repeating word, it will never fit so just use it instead of failing
 				prev = '';
-				newHtml.append(_markupContent(settings.tag, tempLine.html()));
+				newHtml.append(_markupContent(settings.tag, tempLine.html(), lineCount)));
 				tempLine.html('');
 				continue;
 			}
 			if (tempLine.height() > maxHeight) {
 				prev = tempLine.html();
 				tempLine.html(html);
-				newHtml.append(_markupContent(settings.tag, tempLine.html()));
+				newHtml.append(_markupContent(settings.tag, tempLine.html(), lineCount)));
 				tempLine.html('');
 				w--;
+				lineCount++;
 			}
 		}
-		newHtml.append(_markupContent(settings.tag, tempLine.html()));
+		newHtml.append(_markupContent(settings.tag, tempLine.html(), lineCount)));
 
 		this.html(newHtml.html());
 


### PR DESCRIPTION
Count the lines and add the current index as a css variable for easier animation. This is especially useful for delaying each line.

Example: 
animation-delay: calc( .15s * var(--line-index) ); // delays each new line by .15s, first line no delay due to beginning with index 0