### PR TITLE
Fix the behaviors for multiple elements selector

### DIFF
--- a/demos.html
+++ b/demos.html
@@ -126,6 +126,7 @@
 				$('#example-12').splitLines({
 					tag: '<div class="animated-line-wrapper"><div class="animated-line-content">'
 				});
+				$('#example-13 .example').splitLines({width: 200});
 
 				$('#example-6').css('height', 24).children().css({
 					position: 'absolute',
@@ -261,6 +262,32 @@
 					</div>
 					<div id="example-12" class="example">
 						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est libero, eget convallis mauris viverra eu.
+					</div>
+				</div>
+
+				<div>
+					<p>A test showing the plugin works with a selector that returns multiple nodes.</p>
+					<div id="original-13">
+						<div class="original">
+							Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est libero, eget convallis mauris viverra eu.
+						</div>
+						<div class="original">
+							Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est libero, eget convallis mauris viverra eu.
+						</div>
+						<div class="original">
+							Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est libero, eget convallis mauris viverra eu.
+						</div>
+					</div>
+					<div id="example-13">
+						<div class="example">
+							Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est libero, eget convallis mauris viverra eu.
+						</div>
+						<div class="example">
+							Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est libero, eget convallis mauris viverra eu.
+						</div>
+						<div class="example">
+							Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sodales est libero, eget convallis mauris viverra eu.
+						</div>
 					</div>
 				</div>
 			</div>

--- a/jquery.splitlines.js
+++ b/jquery.splitlines.js
@@ -12,158 +12,150 @@
  *	@param options object The options object
  *	@license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-(function ($) {
-  /**
-   * Creates a temporary clone
-   *
-   * @param element element The element to clone
-   */
-  function _createTemp(element) {
-    return element.clone().css({ position: "absolute" });
-  }
+(function($){
+/**
+ * Creates a temporary clone
+ *
+ * @param element element The element to clone
+ */
+	function _createTemp(element) {
+		return element.clone().css({position: 'absolute'});
+	};
 
-  /**
-   * Splits contents into words, keeping their original Html tag. Note that this
-   * tags *each* word with the tag it was found in, so when the wrapping begins
-   * the tags stay intact. This may have an effect on your styles (say, if you have
-   * margin, each word will inherit those styles).
-   *
-   * @param node contents The contents
-   */
-  function _splitHtmlWords(contents) {
-    const words = [];
-    let splitContent;
-    for (let c = 0; c < contents.length; c++) {
-      if (contents[c].nodeName === "BR") {
-        words.push("<br>");
-        continue;
-      }
-      if (contents[c].nodeType === 3) {
-        splitContent = _splitWords(
-          contents[c].textContent || contents[c].toString()
-        );
-      } else {
-        const tag = $(contents[c]).clone();
-        splitContent = _splitHtmlWords(tag.contents());
-        for (let t = 0; t < splitContent.length; t++) {
-          tag.empty();
-          splitContent[t] = tag
-            .html(splitContent[t])
-            .wrap("<p></p>")
-            .parent()
-            .html();
-        }
-      }
-      for (let w = 0; w < splitContent.length; w++) {
-        if (splitContent[w] === "") {
-          continue;
-        }
-        words.push(splitContent[w]);
-      }
-    }
-    return words;
-  }
+/**
+ * Splits contents into words, keeping their original Html tag. Note that this
+ * tags *each* word with the tag it was found in, so when the wrapping begins
+ * the tags stay intact. This may have an effect on your styles (say, if you have
+ * margin, each word will inherit those styles).
+ *
+ * @param node contents The contents
+ */
+	function _splitHtmlWords(contents) {
+		var words = [];
+		var splitContent;
+		for (var c=0; c<contents.length; c++) {
+			if (contents[c].nodeName === 'BR') {
+				words.push('<br>');
+				continue;
+			}
+			if (contents[c].nodeType == 3) {
+				splitContent = _splitWords(contents[c].textContent || contents[c].toString());
+			} else {
+				var tag = $(contents[c]).clone();
+				splitContent = _splitHtmlWords(tag.contents());
+				for (var t=0; t<splitContent.length; t++) {
+					tag.empty();
+					splitContent[t] = tag.html(splitContent[t]).wrap('<p></p>').parent().html();
+				}
+			}
+			for (var w=0; w<splitContent.length; w++) {
+				if (splitContent[w] === '') {
+					continue;
+				}
+				words.push(splitContent[w]);
+			}
+		}
+		return words;
+	};
 
-  /**
-   * Splits words by spaces
-   *
-   * @param string text The text to split
-   */
-  function _splitWords(text) {
-    return text.split(/\s+/);
-  }
+/**
+ * Splits words by spaces
+ *
+ * @param string text The text to split
+ */
+	function _splitWords(text) {
+		return text.split(/\s+/);
+	}
 
-  /**
-   * Formats html with tags and wrappers.
-   *
-   * @param tag
-   * @param html content wrapped by the tag
-   * @param index Current line index
-   */
-  function _markupContent(tag, html, index) {
-    // wrap in a temp div so .html() gives us the tags we specify
-    tag = `<div class="stop">${tag}`;
-    // find the deepest child, add html, then find the parent
-    const $outer = $(tag)
-      .find('*:not(:has("*"))')
-      .html(html)
-      .closest(".stop")
-      .slice(-1);
+/**
+ * Formats html with tags and wrappers.
+ *
+ * @param tag
+ * @param html content wrapped by the tag
+ * @param index Current line index
+ */
+	function _markupContent(tag, html, index) {
+		// wrap in a temp div so .html() gives us the tags we specify
+		tag = '<div class="stop">' + tag;
+		// find the deepest child, add html, then find the parent
+		var $outer = $(tag)
+			.find('*:not(:has("*"))')
+			.html(html)
+			.closest('.stop')
+			.slice(-1);
 
-    // jQuery does not support setting CSS vars until 3.2, so manually set them
-    $outer.children().each(function (i, element) {
-      element.style.setProperty("--line-index", index);
-    });
+		// jQuery does not support setting CSS vars until 3.2, so manually set them
+		$outer.children().each(function (i, element) {
+			element.style.setProperty('--line-index', index);
+		});
 
-    return $outer.html();
-  }
+		return $outer.html();
+	}
 
-  /**
-   * The jQuery plugin function. See the top of this file for information on the
-   * options
-   */
-  $.fn.splitLines = function (options) {
-    const settings = {
-      width: "auto",
-      tag: "<div>",
-      wrap: "",
-      keepHtml: true,
-    };
-    if (options) {
-      $.extend(settings, options);
-    }
+/**
+ * The jQuery plugin function. See the top of this file for information on the
+ * options
+ */
+	$.fn.splitLines = function(options) {
+		var settings = {
+			width: 'auto',
+			tag: '<div>',
+			wrap: '',
+			keepHtml: true
+		};
+		if (options) {
+			$.extend(settings, options);
+		}
 
-    const arr = this;
+		var arr = this;
 
-    for (let index = 0; index < arr.length; index++) {
-      const tmpElement = $(arr[index]);
+		for (var index=0; index<arr.length; index++) {
+			var tmpElement = $(arr[index]);
 
-      const newHtml = _createTemp(tmpElement);
-      const contents = tmpElement.contents();
-      const text = tmpElement.text();
-      tmpElement.append(newHtml);
-      newHtml.text("42");
-      const maxHeight = newHtml.height() + 2;
-      newHtml.empty();
+			var newHtml = _createTemp(tmpElement);
+			var contents = tmpElement.contents();
+			var text = tmpElement.text();
+			tmpElement.append(newHtml);
+			newHtml.text('42');
+			var maxHeight = newHtml.height() + 2;
+			newHtml.empty();
 
-      const tempLine = _createTemp(newHtml);
-      let width = settings.width;
-      if (settings.width === "auto") {
-        width = tmpElement[0].offsetWidth;
-      }
-      tempLine.width(width);
-      tmpElement.append(tempLine);
-      const words = settings.keepHtml
-        ? _splitHtmlWords(contents)
-        : _splitWords(text);
-      let prev;
-      let lineCount = 0;
-      for (let w = 0; w < words.length; w++) {
-        const html = tempLine.html();
-        tempLine.html(`${html + words[w]} `);
-        if (tempLine.html() === prev) {
-          // repeating word, it will never fit so just use it instead of failing
-          prev = "";
-          newHtml.append(
-            _markupContent(settings.tag, tempLine.html(), lineCount)
-          );
-          tempLine.html("");
-          continue;
-        }
-        if (tempLine.height() > maxHeight) {
-          prev = tempLine.html();
-          tempLine.html(html);
-          newHtml.append(
-            _markupContent(settings.tag, tempLine.html(), lineCount)
-          );
-          tempLine.html("");
-          w--;
-          lineCount++;
-        }
-      }
-      newHtml.append(_markupContent(settings.tag, tempLine.html(), lineCount));
+			var tempLine = _createTemp(newHtml);
+			var width = settings.width;
+			if (settings.width === 'auto') {
+				width = tmpElement[0].offsetWidth;
+			}
+			tempLine.width(width);
+			tmpElement.append(tempLine);
+			var words = settings.keepHtml
+				? _splitHtmlWords(contents)
+				: _splitWords(text);
+			var prev;
+			var lineCount=0;
+			for (var w=0; w<words.length; w++) {
+				var html = tempLine.html();
+				tempLine.html('${html + words[w]} ');
+				if (tempLine.html() === prev) {
+					// repeating word, it will never fit so just use it instead of failing
+					prev = '';
+					newHtml.append(
+						_markupContent(settings.tag, tempLine.html(), lineCount)
+					);
+					tempLine.html('');
+					continue;
+				}
+				if (tempLine.height() > maxHeight) {
+					prev = tempLine.html();
+					tempLine.html(html);
+					newHtml.append(_markupContent(settings.tag, tempLine.html(), lineCount));
+					tempLine.html('');
+					w--;
+					lineCount++;
+				}
+			}
+			newHtml.append(_markupContent(settings.tag, tempLine.html(), lineCount));
 
-      tmpElement.html(newHtml.html());
-    }
-  };
+			tmpElement.html(newHtml.html());
+		}
+	};
 })(jQuery);

--- a/jquery.splitlines.js
+++ b/jquery.splitlines.js
@@ -134,7 +134,7 @@
 			var lineCount=0;
 			for (var w=0; w<words.length; w++) {
 				var html = tempLine.html();
-				tempLine.html('${html + words[w]} ');
+				tempLine.html(html+words[w]+' ');
 				if (tempLine.html() === prev) {
 					// repeating word, it will never fit so just use it instead of failing
 					prev = '';


### PR DESCRIPTION
When the selector returned several elements, the script concatenates the different texts and this appears in each of the returned elements.

This pull request separates the processing of the different elements corresponding to the selector.